### PR TITLE
support different replica count per node.

### DIFF
--- a/lib/hash_ring/ets.ex
+++ b/lib/hash_ring/ets.ex
@@ -139,7 +139,7 @@ defmodule HashRing.ETS do
     if has_node_with_name?(nodes, node_name) do
       {:reply, {:error, :node_exists}, state}
     else
-      nodes = [{node_name, num_replicas}|nodes]
+      nodes = [{node_name, num_replicas} | nodes]
       {:reply, {:ok, nodes}, rebuild(%{state | nodes: nodes})}
     end
   end
@@ -234,7 +234,7 @@ defmodule HashRing.ETS do
   end
 
   defp has_node_with_name?(nodes, node_name) do
-    Enum.any?(nodes, fn {existing_node, _} -> existing_node == node_name end)
+    Enum.any?(nodes, &match?({^node_name, _}, &1))
   end
 
   defp transform_nodes(nodes, default_num_replicas) do

--- a/lib/hash_ring/ets.ex
+++ b/lib/hash_ring/ets.ex
@@ -9,7 +9,7 @@ defmodule HashRing.ETS do
   alias HashRing.Utils
   alias HashRing.ETS.Config
 
-  defstruct num_replicas: 0,
+  defstruct default_num_replicas: @default_num_replicas,
             nodes: [],
             table: nil,
             ring_gen: 0,
@@ -19,7 +19,7 @@ defmodule HashRing.ETS do
   def start_link(name, opts \\ []) do
     named = Keyword.get(opts, :named, false)
     nodes = Keyword.get(opts, :nodes, [])
-    num_replicas = Keyword.get(opts, :num_replicas, @default_num_replicas)
+    num_replicas = Keyword.get(opts, :default_num_replicas, @default_num_replicas)
     gen_opts = if named do
       [name: name]
     else
@@ -30,7 +30,7 @@ defmodule HashRing.ETS do
   end
 
   @spec init({atom, [binary], integer}) :: t
-  def init({name, nodes, num_replicas}) do
+  def init({name, nodes, default_num_replicas}) do
     table = :ets.new(:ring, [
       :protected,
       :ordered_set,
@@ -39,8 +39,8 @@ defmodule HashRing.ETS do
 
     state = rebuild(%__MODULE__{
       table: table,
-      num_replicas: num_replicas,
-      nodes: nodes,
+      default_num_replicas: default_num_replicas,
+      nodes: transform_nodes(nodes, default_num_replicas),
       name: name,
     })
 
@@ -51,17 +51,17 @@ defmodule HashRing.ETS do
     GenServer.stop(name)
   end
 
-  @spec set_nodes(atom, [binary]) :: {:ok, [binary]}
+  @spec set_nodes(atom, [binary | {binary, integer}]) :: {:ok, [{binary, integer}]}
   def set_nodes(name, node_names) do
     GenServer.call(name, {:set_nodes, node_names})
   end
 
-  @spec add_node(atom, binary) :: {:ok, [binary]} | {:error, :node_exists}
-  def add_node(name, node_name) do
-    GenServer.call(name, {:add_node, node_name})
+  @spec add_node(atom, binary, integer) :: {:ok, [{binary, integer}]} | {:error, :node_exists}
+  def add_node(name, node_name, num_replicas \\ nil) do
+    GenServer.call(name, {:add_node, node_name, num_replicas})
   end
 
-  @spec remove_node(atom, binary) :: {:ok, [binary]} | {:error, :node_exists}
+  @spec remove_node(atom, binary) :: {:ok, [{binary, integer}]} | {:error, :node_exists}
   def remove_node(name, node_name) do
     GenServer.call(name, {:remove_node, node_name})
   end
@@ -69,6 +69,11 @@ defmodule HashRing.ETS do
   @spec get_nodes(atom) :: {:ok, [binary]}
   def get_nodes(name) do
     GenServer.call(name, :get_nodes)
+  end
+
+  @spec get_nodes(atom) :: {:ok, [{binary, integer}]}
+  def get_nodes_with_replicas(name) do
+    GenServer.call(name, :get_nodes_with_replicas)
   end
 
   @spec force_gc(atom) :: {:ok, [integer]}
@@ -123,26 +128,34 @@ defmodule HashRing.ETS do
     end
   end
 
-  def handle_call({:set_nodes, nodes}, _from, state) do
+  def handle_call({:set_nodes, nodes}, _from, %{default_num_replicas: default_num_replicas}=state) do
+    nodes = transform_nodes(nodes, default_num_replicas)
     {:reply, {:ok, nodes}, rebuild(%{state | nodes: nodes})}
   end
-  def handle_call({:add_node, node_name}, _from, %{nodes: nodes}=state) do
-    if node_name in nodes do
+  def handle_call({:add_node, node_name, nil}, from, %{default_num_replicas: default_num_replicas}=state) do
+    handle_call({:add_node, node_name, default_num_replicas}, from, state)
+  end
+  def handle_call({:add_node, node_name, num_replicas}, _from, %{nodes: nodes}=state) do
+    if has_node_with_name?(nodes, node_name) do
       {:reply, {:error, :node_exists}, state}
     else
-      nodes = [node_name|nodes]
+      nodes = [{node_name, num_replicas}|nodes]
       {:reply, {:ok, nodes}, rebuild(%{state | nodes: nodes})}
     end
   end
   def handle_call({:remove_node, node_name}, _from, %{nodes: nodes}=state) do
-    if node_name in nodes do
-      nodes = nodes -- [node_name]
+    if has_node_with_name?(nodes, node_name) do
+      nodes = Enum.reject(nodes, fn {existing_node, _} -> existing_node == node_name end)
       {:reply, {:ok, nodes}, rebuild(%{state | nodes: nodes})}
     else
       {:reply, {:error, :node_not_exists}, state}
     end
   end
   def handle_call(:get_nodes, _from, %{nodes: nodes}=state) do
+    nodes = for {node_name, _} <- nodes, do: node_name
+    {:reply, {:ok, nodes}, state}
+  end
+  def handle_call(:get_nodes_with_replicas, _from, %{nodes: nodes}=state) do
     {:reply, {:ok, nodes}, state}
   end
 
@@ -183,11 +196,10 @@ defmodule HashRing.ETS do
     {:noreply, %{state | pending_gcs: pending_gcs}}
   end
 
-  defp rebuild(%{nodes: nodes, num_replicas: num_replicas, name: name,
+  defp rebuild(%{nodes: nodes, name: name,
                  table: table, ring_gen: ring_gen}=state) do
     new_ring_gen = ring_gen + 1
-
-    :ets.insert(table, for {hash, node} <- Utils.gen_items(nodes, num_replicas) do
+    :ets.insert(table, for {hash, node} <- Utils.gen_items(nodes) do
       {{new_ring_gen, hash}, node}
     end)
     Config.set(name, self(), {table, new_ring_gen, length(nodes)})
@@ -219,5 +231,16 @@ defmodule HashRing.ETS do
       [{{^ring_gen, number}, node}] -> {number, node}
       _ -> nil
     end
+  end
+
+  defp has_node_with_name?(nodes, node_name) do
+    Enum.any?(nodes, fn {existing_node, _} -> existing_node == node_name end)
+  end
+
+  defp transform_nodes(nodes, default_num_replicas) do
+    Enum.map(nodes, fn
+      {_node, _num_replicas}=item -> item
+      node -> {node, default_num_replicas}
+    end)
   end
 end

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -21,8 +21,10 @@ defmodule HashRing.Utils do
   defp do_gen_items([], items) do
     Enum.sort(items, &(elem(&1, 0) < elem(&2, 0)))
   end
-  defp do_gen_items([{node, num_replicas}|nodes], items) do
-    items = Enum.reduce(0..(num_replicas - 1), items, &([{hash("#{node}#{&1}"), node}|&2]))
+  defp do_gen_items([{node, num_replicas} | nodes], items) do
+    items = Enum.reduce(0..(num_replicas - 1), items, fn replica, acc ->
+      [{hash("#{node}#{replica}"), node} | acc]
+    end)
     do_gen_items(nodes, items)
   end
 end

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -8,17 +8,21 @@ defmodule HashRing.Utils do
   end
   def hash(key), do: hash("#{key}")
 
+  @spec gen_items([{binary, integer}]) :: [{integer, binary}]
   @spec gen_items(binary, integer) :: [{integer, binary}]
+  def gen_items([]), do: []
+  def gen_items(nodes), do: do_gen_items(nodes, [])
   def gen_items([], _num_replicas), do: []
-  def gen_items(nodes, num_replicas) do
-    gen_items(nodes, Enum.to_list(0..(num_replicas - 1)), [])
+  def gen_items(nodes, default_num_replicas) do
+    nodes = for node <- nodes, do: {node, default_num_replicas}
+    gen_items(nodes)
   end
 
-  defp gen_items([], _replicas, items) do
+  defp do_gen_items([], items) do
     Enum.sort(items, &(elem(&1, 0) < elem(&2, 0)))
   end
-  defp gen_items([node|nodes], replicas, items) do
-    items = Enum.reduce(replicas, items, &([{hash("#{node}#{&1}"), node}|&2]))
-    gen_items(nodes, replicas, items)
+  defp do_gen_items([{node, num_replicas}|nodes], items) do
+    items = Enum.reduce(0..(num_replicas - 1), items, &([{hash("#{node}#{&1}"), node}|&2]))
+    do_gen_items(nodes, items)
   end
 end


### PR DESCRIPTION
This PR adds support for allowing different replica counts per node to `HashRing.ETS`.