### PR TITLE
Add `ExHashRing` namespace all modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /_build
 /cover
 /deps
+/bench/snapshots
 erl_crash.dump
 *.ez
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -18,13 +18,15 @@ Add it to `mix.exs`.
 
 ```elixir
 defp deps do
-  [{:ex_hash_ring, "~> 1.0"}]
+  [{:ex_hash_ring, "~> 3.0"}]
 end
 ```
 
 Create a new HashRing.
 
 ```elixir
+alias ExHashRing.HashRing
+
 ring = HashRing.new
 {:ok, ring} = HashRing.add_node(ring, "a")
 {:ok, ring} = HashRing.add_node(ring, "b")
@@ -37,7 +39,7 @@ Find the node for a key.
 "b" = HashRing.find_node(ring, "key3")
 ```
 
-Additionally, you can also use `HashRing.ETS`, which holds the ring in an ETS table for fast access, if you need
+Additionally, you can also use `ExHashRing.HashRing.ETS`, which holds the ring in an ETS table for fast access, if you need
 the ring across multiple processes.
 
 

--- a/bench/ets_hash_ring_bench.exs
+++ b/bench/ets_hash_ring_bench.exs
@@ -1,6 +1,6 @@
 defmodule ETSHashRingBench do
   use Benchfella
-  alias HashRing.ETS, as: Ring
+  alias ExHashRing.HashRing.ETS, as: Ring
 
 
   @nodes [

--- a/bench/hash_ring_bench.exs
+++ b/bench/hash_ring_bench.exs
@@ -1,5 +1,6 @@
 defmodule HashRingBench do
   use Benchfella
+  alias ExHashRing.HashRing
 
   @nodes [
     "hash-ring-1-1",

--- a/lib/ex_hash_ring.ex
+++ b/lib/ex_hash_ring.ex
@@ -2,6 +2,6 @@ defmodule ExHashRing do
   use Application
 
   def start(_type, _args) do
-    HashRing.ETS.Config.start_link()
+    ExHashRing.HashRing.ETS.Config.start_link()
   end
 end

--- a/lib/hash_ring.ex
+++ b/lib/hash_ring.ex
@@ -1,10 +1,10 @@
-defmodule HashRing do
+defmodule ExHashRing.HashRing do
   @compile :native
 
   @type t :: __MODULE__
 
   use Bitwise
-  alias HashRing.Utils
+  alias ExHashRing.HashRing.Utils
 
   defstruct num_replicas: 0, nodes: [], items: {}
 

--- a/lib/hash_ring/ets.ex
+++ b/lib/hash_ring/ets.ex
@@ -1,4 +1,4 @@
-defmodule HashRing.ETS do
+defmodule ExHashRing.HashRing.ETS do
   @default_num_replicas 512
   @default_ring_gen_gc_delay 10_000
 
@@ -6,8 +6,8 @@ defmodule HashRing.ETS do
 
   use GenServer
 
-  alias HashRing.Utils
-  alias HashRing.ETS.Config
+  alias ExHashRing.HashRing.Utils
+  alias ExHashRing.HashRing.ETS.Config
 
   defstruct default_num_replicas: @default_num_replicas,
             nodes: [],

--- a/lib/hash_ring/ets_config.ex
+++ b/lib/hash_ring/ets_config.ex
@@ -1,4 +1,4 @@
-defmodule HashRing.ETS.Config do
+defmodule ExHashRing.HashRing.ETS.Config do
     use GenServer
 
     @type ring_gen :: integer

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -1,4 +1,4 @@
-defmodule HashRing.Utils do
+defmodule ExHashRing.HashRing.Utils do
   @compile :native
 
   @spec hash(atom | binary | integer) :: integer

--- a/mix.exs
+++ b/mix.exs
@@ -1,10 +1,10 @@
-defmodule HashRing.Mixfile do
+defmodule ExHashRing.HashRing.Mixfile do
   use Mix.Project
 
   def project do
     [
       app: :ex_hash_ring,
-      version: "2.0.0",
+      version: "3.0.0",
       elixir: "~> 1.3",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,

--- a/test/ets_hash_ring_test.exs
+++ b/test/ets_hash_ring_test.exs
@@ -1,7 +1,7 @@
 defmodule ETSHashRingTest do
   use ExUnit.Case
   alias HashRingTest.Support.Harness
-  alias HashRing.ETS, as: Ring
+  alias ExHashRing.HashRing.ETS, as: Ring
 
   setup_all do
     rings = for num_replicas <- Harness.replicas(), into: %{} do
@@ -28,7 +28,7 @@ end
 
 defmodule ETSHashRingOperationsTest do
   use ExUnit.Case
-  alias HashRing.ETS, as: Ring
+  alias ExHashRing.HashRing.ETS, as: Ring
 
   @default_num_replicas 512
   @nodes ["a", "b", "c"]
@@ -158,7 +158,7 @@ defmodule ETSHashRingOperationsTest do
     assert Ring.find_nodes(HashRingEtsTest.DoesNotExist, 1, 2) == {:error, :no_ring}
   end
 
-  test "HashRing.ETS.start_link/1" do
+  test "ExHashRing.HashRing.ETS.start_link/1" do
     {:ok, _pid} = Ring.start_link(TestModule.Foo, nodes: @nodes)
     assert Ring.find_node(TestModule.Foo, 1) == {:ok, "c"}
     assert Process.whereis(TestModule.Foo) == nil

--- a/test/hash_ring_test.exs
+++ b/test/hash_ring_test.exs
@@ -1,6 +1,7 @@
 defmodule HashRingTest do
   use ExUnit.Case
   alias HashRingTest.Support.Harness
+  alias ExHashRing.HashRing
 
   setup_all do
     rings = for num_replicas <- Harness.replicas(), into: %{} do


### PR DESCRIPTION
Both this package and `libring` export a `HashRing` module without
any top-level namespace. This diff adds a top-level namespace of
`ExHashRing` to avoid the conflict.

Fixes #3