### PR TITLE
overrides for specific keys. 

### DIFF
--- a/bench/ets_hash_ring_bench.exs
+++ b/bench/ets_hash_ring_bench.exs
@@ -2,47 +2,70 @@ defmodule ETSHashRingBench do
   use Benchfella
   alias ExHashRing.HashRing.ETS, as: Ring
 
-  @nodes [
-    "hash-ring-1-1",
-    "hash-ring-1-2",
-    "hash-ring-1-3",
-    "hash-ring-1-4"
-  ]
-  @replicas 512
   @name HashRingBench.ETSRing
+  @nodes ["hash-ring-1-1", "hash-ring-1-2", "hash-ring-1-3", "hash-ring-1-4"]
+  @replicas 512
+  @overrides %{"1234254543" => 1}
 
   setup_all do
     Ring.Config.start_link()
     {:ok, nil}
   end
 
-  before_each_bench _ do
-    {:ok, _pid} = Ring.start_link(@name, nodes: @nodes, num_replicas: @replicas, named: true)
-    {:ok, @name}
-  end
-
   after_each_bench _ do
     GenServer.stop(@name)
   end
 
-  bench "find node" do
-    Ring.find_node(bench_context, "1234254543")
+  bench "find_node", ring: new_ring() do
+    Ring.find_node(ring, "1234254543")
     :ok
   end
 
-  bench "find nodes (1)" do
-    Ring.find_nodes(bench_context, "1234254543", 2)
+  bench "find_nodes(num: 2)", ring: new_ring() do
+    Ring.find_nodes(ring, "1234254543", 2)
     :ok
   end
 
-  bench "find nodes (2)" do
-    Ring.find_nodes(bench_context, "1234254543", 3)
+  bench "find_nodes(num: 3)", ring: new_ring() do
+    Ring.find_nodes(ring, "1234254543", 3)
     :ok
   end
 
-  bench "regenerate ring & gc" do
-    Ring.set_nodes(bench_context, @nodes)
-    Ring.force_gc(bench_context)
+  bench "find_node [override, match=true]", ring: new_ring(@overrides) do
+    Ring.find_node(ring, "1234254543")
+    :ok
+  end
+
+  bench "find_node [override, match=false]", ring: new_ring(@overrides) do
+    Ring.find_node(ring, "0")
+    :ok
+  end
+
+  bench "find_nodes(num: 2) [override]", ring: new_ring(@overrides) do
+    Ring.find_nodes(ring, "1234254543", 2)
+    :ok
+  end
+
+  bench "find_nodes(num: 3) [override]", ring: new_ring(@overrides) do
+    Ring.find_nodes(ring, "1234254543", 3)
+    :ok
+  end
+
+  bench "regenerate ring & gc", ring: new_ring() do
+    Ring.set_nodes(ring, @nodes)
+    Ring.force_gc(ring)
     nil
+  end
+
+  defp new_ring(overrides \\ %{}) do
+    {:ok, _} =
+      Ring.start_link(@name,
+        nodes: @nodes,
+        num_replicas: @replicas,
+        overrides: overrides,
+        named: true
+      )
+
+    @name
   end
 end

--- a/bench/ets_hash_ring_bench.exs
+++ b/bench/ets_hash_ring_bench.exs
@@ -36,18 +36,28 @@ defmodule ETSHashRingBench do
     :ok
   end
 
+  bench "find_nodes(num: 2) [override, match=true]", ring: new_ring(@overrides) do
+    Ring.find_nodes(ring, "1234254543", 2)
+    :ok
+  end
+
+  bench "find_nodes(num: 3) [override, match=true]", ring: new_ring(@overrides) do
+    Ring.find_nodes(ring, "1234254543", 3)
+    :ok
+  end
+
   bench "find_node [override, match=false]", ring: new_ring(@overrides) do
     Ring.find_node(ring, "0")
     :ok
   end
 
-  bench "find_nodes(num: 2) [override]", ring: new_ring(@overrides) do
-    Ring.find_nodes(ring, "1234254543", 2)
+  bench "find_nodes(num: 2) [override, match=false]", ring: new_ring(@overrides) do
+    Ring.find_nodes(ring, "0", 2)
     :ok
   end
 
-  bench "find_nodes(num: 3) [override]", ring: new_ring(@overrides) do
-    Ring.find_nodes(ring, "1234254543", 3)
+  bench "find_nodes(num: 3) [override, match=false]", ring: new_ring(@overrides) do
+    Ring.find_nodes(ring, "0", 3)
     :ok
   end
 

--- a/bench/hash_ring_bench.exs
+++ b/bench/hash_ring_bench.exs
@@ -2,30 +2,46 @@ defmodule HashRingBench do
   use Benchfella
   alias ExHashRing.HashRing
 
-  @nodes [
-    "hash-ring-1-1",
-    "hash-ring-1-2",
-    "hash-ring-1-3",
-    "hash-ring-1-4"
-  ]
+  @nodes ["hash-ring-1-1", "hash-ring-1-2", "hash-ring-1-3", "hash-ring-1-4"]
   @replicas 512
+  @overrides %{"1234254543" => 1}
 
-  before_each_bench _ do
-    {:ok, HashRing.new(@nodes, @replicas)}
-  end
-
-  bench "find node" do
-    HashRing.find_node(bench_context, "1234254543")
+  bench "find_node", ring: new_ring() do
+    HashRing.find_node(ring, "1234254543")
     :ok
   end
 
-  bench "find nodes (1)" do
-    HashRing.find_nodes(bench_context, "1234254543", 2)
+  bench "find_nodes(num: 2)", ring: new_ring() do
+    HashRing.find_nodes(ring, "1234254543", 2)
     :ok
   end
 
-  bench "find nodes (2)" do
-    HashRing.find_nodes(bench_context, "1234254543", 3)
+  bench "find_nodes(num: 3)", ring: new_ring() do
+    HashRing.find_nodes(ring, "1234254543", 3)
     :ok
+  end
+
+  bench "find_node [override, match=true]", ring: new_ring(@overrides) do
+    HashRing.find_node(ring, "1234254543")
+    :ok
+  end
+
+  bench "find_node [override, match=false]", ring: new_ring(@overrides) do
+    HashRing.find_node(ring, "1234254544")
+    :ok
+  end
+
+  bench "find_nodes(num: 2) [override]", ring: new_ring(@overrides) do
+    HashRing.find_nodes(ring, "1234254543", 2)
+    :ok
+  end
+
+  bench "find_nodes(num: 3) [override]", ring: new_ring(@overrides) do
+    HashRing.find_nodes(ring, "1234254543", 3)
+    :ok
+  end
+
+  defp new_ring(overrides \\ %{}) do
+    HashRing.new(@nodes, @replicas, overrides)
   end
 end

--- a/lib/hash_ring.ex
+++ b/lib/hash_ring.ex
@@ -65,12 +65,12 @@ defmodule ExHashRing.HashRing do
   @spec find_nodes(t, binary | integer, integer) :: [binary]
   def find_nodes(%{items: items, nodes: nodes, overrides: overrides}, key, num)
       when num > 0 and map_size(overrides) > 0 do
+    nodes = do_find_nodes(items, min(num, length(nodes)), Utils.hash(key), [])
+
     if override = find_override(overrides, key) do
-      remaining = min(num - 1, length(nodes))
-      do_find_nodes(items, remaining, Utils.hash(key), [override])
+      ([override] ++ (nodes -- [override])) |> Enum.take(num)
     else
-      remaining = min(num, length(nodes))
-      do_find_nodes(items, remaining, Utils.hash(key), [])
+      nodes
     end
   end
 

--- a/lib/hash_ring.ex
+++ b/lib/hash_ring.ex
@@ -40,7 +40,7 @@ defmodule ExHashRing.HashRing do
     end
   end
 
-  @spec set_overrides(t, override_map) :: {:ok, override_map}
+  @spec set_overrides(t, override_map) :: {:ok, t}
   def set_overrides(ring, overrides) do
     {:ok, rebuild(%{ring | overrides: overrides})}
   end

--- a/lib/hash_ring.ex
+++ b/lib/hash_ring.ex
@@ -68,7 +68,7 @@ defmodule ExHashRing.HashRing do
     nodes = do_find_nodes(items, min(num, length(nodes)), Utils.hash(key), [])
 
     if override = find_override(overrides, key) do
-      ([override] ++ (nodes -- [override])) |> Enum.take(num)
+      ([override] ++ (nodes -- [override])) |> Utils.take(num)
     else
       nodes
     end

--- a/lib/hash_ring.ex
+++ b/lib/hash_ring.ex
@@ -2,18 +2,19 @@ defmodule ExHashRing.HashRing do
   @compile :native
 
   @type t :: __MODULE__
+  @type override_map :: %{atom => binary}
 
   use Bitwise
   alias ExHashRing.HashRing.Utils
 
-  defstruct num_replicas: 0, nodes: [], items: {}
+  defstruct num_replicas: 0, nodes: [], overrides: %{}, items: {}
 
   @spec new :: t
   def new, do: new([])
 
-  @spec new([binary], integer) :: t
-  def new(nodes, num_replicas \\ 512) do
-    rebuild(%__MODULE__{nodes: nodes, num_replicas: num_replicas})
+  @spec new([binary], override_map, integer) :: t
+  def new(nodes, num_replicas \\ 512, overrides \\ %{}) do
+    rebuild(%__MODULE__{nodes: nodes, overrides: overrides, num_replicas: num_replicas})
   end
 
   @spec set_nodes(t, [binary]) :: t
@@ -39,10 +40,37 @@ defmodule ExHashRing.HashRing do
     end
   end
 
+  @spec set_overrides(t, override_map) :: {:ok, override_map}
+  def set_overrides(ring, overrides) do
+    {:ok, rebuild(%{ring | overrides: overrides})}
+  end
+
   @spec find_node(t, binary | integer) :: binary | nil
-  def find_node(%{items: items}, key) do
+  def find_node(%{overrides: overrides} = ring, key) when map_size(overrides) > 0 do
+    find_override(overrides, key) || find_node_inner(ring, key)
+  end
+
+  @spec find_node(t, binary | integer) :: binary | nil
+  def find_node(ring, key) do
+    find_node_inner(ring, key)
+  end
+
+  @spec find_node_inner(t, binary | integer) :: binary | nil
+  defp find_node_inner(%{items: items}, key) do
     with {_, name} <- find_next_highest_item(items, Utils.hash(key)) do
       name
+    end
+  end
+
+  @spec find_nodes(t, binary | integer, integer) :: [binary]
+  def find_nodes(%{items: items, nodes: nodes, overrides: overrides}, key, num)
+      when num > 0 and map_size(overrides) > 0 do
+    if override = find_override(overrides, key) do
+      remaining = min(num - 1, length(nodes))
+      do_find_nodes(items, remaining, Utils.hash(key), [override])
+    else
+      remaining = min(num, length(nodes))
+      do_find_nodes(items, remaining, Utils.hash(key), [])
     end
   end
 
@@ -69,6 +97,13 @@ defmodule ExHashRing.HashRing do
 
   defp rebuild(%{nodes: nodes} = ring) do
     %{ring | items: Utils.gen_items(nodes, ring.num_replicas) |> List.to_tuple()}
+  end
+
+  def find_override(overrides, key) do
+    case overrides do
+      %{^key => value} -> value
+      _ -> nil
+    end
   end
 
   defp find_next_highest_item(items, key_int) do

--- a/lib/hash_ring.ex
+++ b/lib/hash_ring.ex
@@ -65,13 +65,13 @@ defmodule ExHashRing.HashRing do
   @spec find_nodes(t, binary | integer, integer) :: [binary]
   def find_nodes(%{items: items, nodes: nodes, overrides: overrides}, key, num)
       when num > 0 and map_size(overrides) > 0 do
-    nodes = do_find_nodes(items, min(num, length(nodes)), Utils.hash(key), [])
+    {base, remaining} =
+      case overrides do
+        %{^key => override} -> {[override], num - 1}
+        _ -> {[], num}
+      end
 
-    if override = find_override(overrides, key) do
-      ([override] ++ (nodes -- [override])) |> Utils.take(num)
-    else
-      nodes
-    end
+    do_find_nodes(items, min(remaining, length(nodes)), Utils.hash(key), base)
   end
 
   @spec find_nodes(t, binary | integer, integer) :: [binary]

--- a/lib/hash_ring/ets.ex
+++ b/lib/hash_ring/ets.ex
@@ -161,7 +161,7 @@ defmodule ExHashRing.HashRing.ETS do
 
         {:ok, nodes}
 
-      {:ok, {table, gen, num_nodes, overrides}} when num_nodes > 0 and num > 0 ->
+      {:ok, {table, gen, num_nodes, overrides}} when num_nodes > 0 ->
         nodes = do_find_nodes(table, gen, num_nodes, min(num, num_nodes), hash, [])
 
         if override = find_override(overrides, key) do
@@ -171,9 +171,6 @@ defmodule ExHashRing.HashRing.ETS do
         else
           {:ok, nodes}
         end
-
-      {:ok, {_, _, num_nodes, _}} when num_nodes > 0 ->
-        {:ok, []}
 
       {:error, error} ->
         {:error, error}

--- a/lib/hash_ring/ets.ex
+++ b/lib/hash_ring/ets.ex
@@ -165,7 +165,7 @@ defmodule ExHashRing.HashRing.ETS do
         nodes = do_find_nodes(table, gen, num_nodes, min(num, num_nodes), hash, [])
 
         if override = find_override(overrides, key) do
-          nodes = ([override] ++ (nodes -- [override])) |> Enum.take(num)
+          nodes = ([override] ++ (nodes -- [override])) |> Utils.take(num)
 
           {:ok, nodes}
         else

--- a/lib/hash_ring/ets_config.ex
+++ b/lib/hash_ring/ets_config.ex
@@ -3,13 +3,16 @@ defmodule ExHashRing.HashRing.ETS.Config do
 
   @type ring_gen :: integer
   @type num_nodes :: integer
-  @type config :: {reference, ring_gen, num_nodes}
+  @type overrides :: %{atom => binary}
+  @type config :: {reference, ring_gen, num_nodes} | {reference, ring_gen, num_nodes, overrides}
+
   defstruct monitored_pids: %{}
 
   def start_link() do
     GenServer.start_link(__MODULE__, nil, name: __MODULE__)
   end
 
+  @spec init(any) :: {:ok, ExHashRing.HashRing.ETS.Config.t()}
   def init(_) do
     :ets.new(__MODULE__, [
       :protected,
@@ -26,7 +29,7 @@ defmodule ExHashRing.HashRing.ETS.Config do
     GenServer.call(__MODULE__, {:set, name, owner_pid, config})
   end
 
-  @spec get(atom) :: {:ok, config} | :error
+  @spec get(atom) :: {:ok, config} | {:error, :no_ring}
   def get(name) do
     case :ets.lookup(__MODULE__, name) do
       [{^name, config}] -> {:ok, config}

--- a/lib/hash_ring/ets_config.ex
+++ b/lib/hash_ring/ets_config.ex
@@ -1,6 +1,7 @@
 defmodule ExHashRing.HashRing.ETS.Config do
   use GenServer
 
+  @type t :: __MODULE__
   @type ring_gen :: integer
   @type num_nodes :: integer
   @type overrides :: %{atom => binary}
@@ -12,7 +13,7 @@ defmodule ExHashRing.HashRing.ETS.Config do
     GenServer.start_link(__MODULE__, nil, name: __MODULE__)
   end
 
-  @spec init(any) :: {:ok, ExHashRing.HashRing.ETS.Config.t()}
+  @spec init(any) :: {:ok, t}
   def init(_) do
     :ets.new(__MODULE__, [
       :protected,

--- a/lib/hash_ring/ets_config.ex
+++ b/lib/hash_ring/ets_config.ex
@@ -1,7 +1,7 @@
 defmodule ExHashRing.HashRing.ETS.Config do
   use GenServer
 
-  @type t :: __MODULE__
+  @type t :: %__MODULE__{}
   @type ring_gen :: integer
   @type num_nodes :: integer
   @type overrides :: %{atom => binary}

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -1,5 +1,6 @@
 defmodule ExHashRing.HashRing.Utils do
   @compile :native
+  @compile {:inline, take: 2}
 
   @spec hash(atom | binary | integer) :: integer
   def hash(key) when is_binary(key) do
@@ -32,4 +33,12 @@ defmodule ExHashRing.HashRing.Utils do
 
     do_gen_items(nodes, items)
   end
+
+  def take(_, 0), do: []
+  def take([a | _], 1), do: [a]
+  def take([a, b | _], 2), do: [a, b]
+  def take([a, b, c | _], 3), do: [a, b, c]
+  def take([a, b, c, d | _], 4), do: [a, b, c, d]
+  def take([a, b, c, d, e | _], 5), do: [a, b, c, d, e]
+  def take(list, n), do: Enum.take(list, n)
 end

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -1,6 +1,5 @@
 defmodule ExHashRing.HashRing.Utils do
   @compile :native
-  @compile {:inline, take: 2}
 
   @spec hash(atom | binary | integer) :: integer
   def hash(key) when is_binary(key) do
@@ -33,12 +32,4 @@ defmodule ExHashRing.HashRing.Utils do
 
     do_gen_items(nodes, items)
   end
-
-  def take(_, 0), do: []
-  def take([a | _], 1), do: [a]
-  def take([a, b | _], 2), do: [a, b]
-  def take([a, b, c | _], 3), do: [a, b, c]
-  def take([a, b, c, d | _], 4), do: [a, b, c, d]
-  def take([a, b, c, d, e | _], 5), do: [a, b, c, d, e]
-  def take(list, n), do: Enum.take(list, n)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExHashRing.HashRing.Mixfile do
   def project do
     [
       app: :ex_hash_ring,
-      version: "3.0.0",
+      version: "4.0.0",
       elixir: "~> 1.3",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/ets_hash_ring_test.exs
+++ b/test/ets_hash_ring_test.exs
@@ -181,7 +181,11 @@ defmodule ETSHashRingOperationsTest do
   end
 
   defp count_ring_gen_entries(name, ring_gen) do
-    {:ok, {table, _, _}} = Ring.Config.get(name)
+    table =
+      case Ring.Config.get(name) do
+        {:ok, {table, _, _}} -> table
+        {:ok, {table, _, _, _}} -> table
+      end
 
     :ets.tab2list(table)
     |> Enum.filter(fn {{ring_gen_, _}, _} -> ring_gen_ == ring_gen end)
@@ -189,7 +193,12 @@ defmodule ETSHashRingOperationsTest do
   end
 
   defp ring_ets_table_size(name) do
-    {:ok, {table, _, _}} = Ring.Config.get(name)
+    table =
+      case Ring.Config.get(name) do
+        {:ok, {table, _, _}} -> table
+        {:ok, {table, _, _, _}} -> table
+      end
+
     :ets.info(table, :size)
   end
 

--- a/test/ets_hash_ring_test.exs
+++ b/test/ets_hash_ring_test.exs
@@ -45,7 +45,7 @@ defmodule ETSHashRingOverrideTest do
 
   @harness_overrides Enum.take(Harness.keys(), 5)
   @custom_overrides ["override_string", :override_atom, 123]
-  @override_test_keys @custom_overrides ++ Harness.keys()
+  @override_test_keys @custom_overrides ++ @harness_overrides
   @override_map @override_test_keys |> Enum.map(&{&1, "#{&1} (override)"}) |> Map.new()
 
   setup_all do

--- a/test/ets_hash_ring_test.exs
+++ b/test/ets_hash_ring_test.exs
@@ -6,7 +6,7 @@ defmodule ETSHashRingTest do
   setup_all do
     rings =
       for num_replicas <- Harness.replicas(), into: %{} do
-        name = :"HashRingETSTest.Replicas#{num_replicas}"
+        name = :"ETSHashRingTest.Replicas#{num_replicas}"
 
         {:ok, _pid} =
           Ring.start_link(name,
@@ -32,6 +32,69 @@ defmodule ETSHashRingTest do
         test "find_nodes key=#{key} num=#{Harness.num()}", %{rings: rings} do
           assert Ring.find_nodes(rings[unquote(num_replicas)], unquote(key), Harness.num()) ==
                    {:ok, Harness.find_nodes(unquote(num_replicas), unquote(key), Harness.num())}
+        end
+      end
+    end
+  end
+end
+
+defmodule ETSHashRingOverrideTest do
+  use ExUnit.Case
+  alias HashRingTest.Support.Harness
+  alias ExHashRing.HashRing.ETS, as: Ring
+
+  @harness_overrides Enum.take(Harness.keys(), 5)
+  @custom_overrides ["override_string", :override_atom, 123]
+  @override_test_keys @custom_overrides ++ Harness.keys()
+  @override_map @override_test_keys |> Enum.map(&{&1, "#{&1} (override)"}) |> Map.new()
+
+  setup_all do
+    rings =
+      for num_replicas <- Harness.replicas(), into: %{} do
+        name = :"ETSHashRingOverrideTest.Replicas#{num_replicas}"
+
+        {:ok, _pid} =
+          Ring.start_link(name,
+            nodes: Harness.nodes(),
+            default_num_replicas: num_replicas,
+            named: true
+          )
+
+        Ring.set_overrides(name, @override_map)
+
+        {num_replicas, name}
+      end
+
+    {:ok, rings: rings}
+  end
+
+  for num_replicas <- Harness.replicas() do
+    describe "ets hash ring, replicas=#{num_replicas} overrides=true" do
+      for key <- Harness.keys() do
+        test "find_node key=#{key} overrides=true", %{rings: rings} do
+          found = Ring.find_node(rings[unquote(num_replicas)], unquote(key))
+
+          expected =
+            Map.get(
+              @override_map,
+              unquote(key),
+              Harness.find_node(unquote(num_replicas), unquote(key))
+            )
+
+          assert found == {:ok, expected}
+        end
+
+        test "find_nodes key=#{key} num=#{Harness.num()} overrides=true", %{rings: rings} do
+          found = Ring.find_nodes(rings[unquote(num_replicas)], unquote(key), Harness.num())
+          harness = Harness.find_nodes(unquote(num_replicas), unquote(key), Harness.num())
+          override = [Map.get(@override_map, unquote(key))]
+
+          expected =
+            (override ++ harness)
+            |> Enum.filter(& &1)
+            |> Enum.take(Harness.num())
+
+          assert found == {:ok, expected}
         end
       end
     end
@@ -109,7 +172,7 @@ defmodule ETSHashRingOperationsTest do
     assert Ring.find_node(name, 1) == {:ok, "c"}
   end
 
-  test "remmove node", %{name: name} do
+  test "remove node", %{name: name} do
     expected_nodes = @nodes -- ["c"]
     expected_nodes_with_replicas = for node <- expected_nodes, do: {node, @default_num_replicas}
     {:ok, _} = Ring.remove_node(name, "c")
@@ -118,6 +181,34 @@ defmodule ETSHashRingOperationsTest do
     # Select a node that should now be b.
     assert Ring.get_ring_gen(name) == {:ok, 2}
     assert Ring.find_node(name, 1) == {:ok, "b"}
+  end
+
+  test "set overrides", %{name: name} do
+    new_overrides = %{
+      "1" => 1,
+      :a => 2,
+      3 => 3
+    }
+
+    {:ok, ^new_overrides} = Ring.set_overrides(name, new_overrides)
+    {:ok, ^new_overrides} = Ring.get_overrides(name)
+
+    # Assert that the ring is also re-generated at this point.
+    assert Ring.get_ring_gen(name) == {:ok, 2}
+
+    resolved_overrides =
+      Enum.map(new_overrides, fn {key, _} ->
+        {:ok, value} = Ring.find_node(name, key)
+        {key, value}
+      end)
+
+    assert new_overrides == Map.new(resolved_overrides)
+  end
+
+  test "no initial overrides", %{name: name} do
+    {:ok, overrides} = Ring.get_overrides(name)
+
+    assert map_size(overrides) == 0
   end
 
   test "ets config will remove config", %{name: name} do

--- a/test/ets_hash_ring_test.exs
+++ b/test/ets_hash_ring_test.exs
@@ -73,15 +73,10 @@ defmodule ETSHashRingOverrideTest do
       for key <- Harness.keys() do
         test "find_node key=#{key} overrides=true", %{rings: rings} do
           found = Ring.find_node(rings[unquote(num_replicas)], unquote(key))
+          override = Map.get(@override_map, unquote(key))
+          harness = Harness.find_node(unquote(num_replicas), unquote(key))
 
-          expected =
-            Map.get(
-              @override_map,
-              unquote(key),
-              Harness.find_node(unquote(num_replicas), unquote(key))
-            )
-
-          assert found == {:ok, expected}
+          assert found == {:ok, override || harness}
         end
 
         test "find_nodes key=#{key} num=#{Harness.num()} overrides=true", %{rings: rings} do

--- a/test/hash_ring_test.exs
+++ b/test/hash_ring_test.exs
@@ -36,7 +36,7 @@ defmodule HashRingOverrideTest do
 
   @harness_overrides Enum.take(Harness.keys(), 5)
   @custom_overrides ["override_string", :override_atom, 123]
-  @override_test_keys @custom_overrides ++ Harness.keys()
+  @override_test_keys @custom_overrides ++ @harness_overrides
   @override_map @override_test_keys |> Enum.map(&{&1, "#{&1} (override)"}) |> Map.new()
 
   setup_all do

--- a/test/hash_ring_test.exs
+++ b/test/hash_ring_test.exs
@@ -56,15 +56,10 @@ defmodule HashRingOverrideTest do
       for key <- Harness.keys() do
         test "find_node key=#{key} overrides=true", %{rings: rings} do
           found = HashRing.find_node(rings[unquote(num_replicas)], unquote(key))
+          override = Map.get(@override_map, unquote(key))
+          harness = Harness.find_node(unquote(num_replicas), unquote(key))
 
-          expected =
-            Map.get(
-              @override_map,
-              unquote(key),
-              Harness.find_node(unquote(num_replicas), unquote(key))
-            )
-
-          assert found == expected
+          assert found == override || harness
         end
 
         test "find_nodes key=#{key} num=#{Harness.num()} overrides=true", %{rings: rings} do

--- a/test/hash_ring_test.exs
+++ b/test/hash_ring_test.exs
@@ -28,3 +28,58 @@ defmodule HashRingTest do
     end
   end
 end
+
+defmodule HashRingOverrideTest do
+  use ExUnit.Case
+  alias HashRingTest.Support.Harness
+  alias ExHashRing.HashRing
+
+  @harness_overrides Enum.take(Harness.keys(), 5)
+  @custom_overrides ["override_string", :override_atom, 123]
+  @override_test_keys @custom_overrides ++ Harness.keys()
+  @override_map @override_test_keys |> Enum.map(&{&1, "#{&1} (override)"}) |> Map.new()
+
+  setup_all do
+    rings =
+      for num_replicas <- Harness.replicas(), into: %{} do
+        ring = HashRing.new(Harness.nodes(), num_replicas)
+        {:ok, ring} = HashRing.set_overrides(ring, @override_map)
+
+        {num_replicas, ring}
+      end
+
+    {:ok, rings: rings}
+  end
+
+  for num_replicas <- Harness.replicas() do
+    describe "hash ring, replicas=#{num_replicas} overrides=true" do
+      for key <- Harness.keys() do
+        test "find_node key=#{key} overrides=true", %{rings: rings} do
+          found = HashRing.find_node(rings[unquote(num_replicas)], unquote(key))
+
+          expected =
+            Map.get(
+              @override_map,
+              unquote(key),
+              Harness.find_node(unquote(num_replicas), unquote(key))
+            )
+
+          assert found == expected
+        end
+
+        test "find_nodes key=#{key} num=#{Harness.num()} overrides=true", %{rings: rings} do
+          found = HashRing.find_nodes(rings[unquote(num_replicas)], unquote(key), Harness.num())
+          harness = Harness.find_nodes(unquote(num_replicas), unquote(key), Harness.num())
+          override = [Map.get(@override_map, unquote(key))]
+
+          expected =
+            (override ++ harness)
+            |> Enum.filter(& &1)
+            |> Enum.take(Harness.num())
+
+          assert found == expected
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- allows clients to provide specific key overrides for a ring.
- performance is generally improved.
- effectively zero performance impact when using small number of overrides (relative to v3.0.0).

|                        |        before |         after |        + override |
| :--------------------- | ------------: | ------------: | ----------------: |
| `find_node`            |    0.73 µs/op |    0.73 µs/op | 0.17 - 0.73 µs/op |
| `find_nodes(num: 2)`   |    1.61 µs/op |    1.55 µs/op | 0.79 - 1.08 µs/op |
| `find_nodes(num: 3)`   |    2.17 µs/op |    2.12 µs/op | 1.63 - 2.18 µs/op |
| `regenerate ring & gc` | 2974.22 µs/op | 3064.08 µs/op |     3008.48 µs/op |