### PR TITLE
multiple overrides for a given key.

### DIFF
--- a/lib/hash_ring.ex
+++ b/lib/hash_ring.ex
@@ -42,11 +42,10 @@ defmodule ExHashRing.HashRing do
 
   @spec set_overrides(t, override_map) :: {:ok, t}
   def set_overrides(ring, overrides) do
-    # pre-process the override lists. our search algorithm does its search back-to-front, then reverses the result.
     overrides =
       overrides
       |> Enum.filter(fn {_, values} -> length(values) > 0 end)
-      |> Map.new(fn {key, values} -> {key, Enum.reverse(values)} end)
+      |> Map.new()
 
     {:ok, rebuild(%{ring | overrides: overrides})}
   end
@@ -73,8 +72,12 @@ defmodule ExHashRing.HashRing do
       when num > 0 and map_size(overrides) > 0 do
     {found, found_length} =
       case overrides do
-        %{^key => overrides} -> Utils.take_max(overrides, num)
-        _ -> {[], 0}
+        %{^key => overrides} ->
+          {nodes, length} = Utils.take_max(overrides, num)
+          {Enum.reverse(nodes), length}
+
+        _ ->
+          {[], 0}
       end
 
     do_find_nodes(
@@ -118,7 +121,7 @@ defmodule ExHashRing.HashRing do
 
   def find_override(overrides, key) do
     case overrides do
-      %{^key => values} -> List.last(values)
+      %{^key => values} -> hd(values)
       _ -> nil
     end
   end

--- a/lib/hash_ring/ets_config.ex
+++ b/lib/hash_ring/ets_config.ex
@@ -4,8 +4,9 @@ defmodule ExHashRing.HashRing.ETS.Config do
   @type t :: %__MODULE__{}
   @type ring_gen :: integer
   @type num_nodes :: integer
-  @type overrides :: %{atom => binary}
-  @type config :: {reference, ring_gen, num_nodes} | {reference, ring_gen, num_nodes, overrides}
+  @type override_map :: %{atom => [binary]}
+  @type config ::
+          {reference, ring_gen, num_nodes} | {reference, ring_gen, num_nodes, override_map}
 
   defstruct monitored_pids: %{}
 

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -1,5 +1,6 @@
 defmodule ExHashRing.HashRing.Utils do
   @compile :native
+  @compile {:inline, do_take_max: 3, take_max: 2}
 
   @spec hash(atom | binary | integer) :: integer
   def hash(key) when is_binary(key) do
@@ -31,5 +32,25 @@ defmodule ExHashRing.HashRing.Utils do
       end)
 
     do_gen_items(nodes, items)
+  end
+
+  @spec take_max(list :: list, maximum :: integer) :: {list :: list, count :: integer}
+  def take_max(list, maximum)
+  def take_max(_, 0), do: {[], 0}
+  def take_max(list, maximum) when maximum > 0, do: do_take_max(list, maximum, 0)
+
+  @spec do_take_max(list, remaining :: integer, count :: integer) :: {list, count :: integer}
+  defp do_take_max([head | _], 1, count) do
+    {[head], count + 1}
+  end
+
+  defp do_take_max([head | tail], remaining, count) do
+    {tail, count} = do_take_max(tail, remaining - 1, count + 1)
+
+    {[head | tail], count}
+  end
+
+  defp do_take_max([], _remaining, count) do
+    {[], count}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExHashRing.HashRing.Mixfile do
   def project do
     [
       app: :ex_hash_ring,
-      version: "4.0.0",
+      version: "5.0.0",
       elixir: "~> 1.3",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
- adds support for specifying multiple overrides for a given key (a list of overrides).
- i've put some energy into making the multi-lookup fast (`find_nodes`), but not the singular `find_node` version. i can put some energy into doing that if we feel it is necessary.
- that's it.