### PR TITLE
Fix Some Travis CI Issues

### DIFF
--- a/lib/hash_ring.ex
+++ b/lib/hash_ring.ex
@@ -73,8 +73,8 @@ defmodule ExHashRing.HashRing do
     {found, found_length} =
       case overrides do
         %{^key => overrides} ->
-          {nodes, length} = Utils.take_max(overrides, num)
-          {Enum.reverse(nodes), length}
+          {nodes2, length} = Utils.take_max(overrides, num)
+          {Enum.reverse(nodes2), length}
 
         _ ->
           {[], 0}

--- a/test/ets_hash_ring_test.exs
+++ b/test/ets_hash_ring_test.exs
@@ -208,7 +208,7 @@ defmodule ETSHashRingOperationsTest do
       assert {:ok, value} == Ring.find_nodes(name, key, length(value))
 
       # assert that a lookup of the first half of these items returns the correct half.
-      half = Enum.take(value, Kernel.ceil(length(value) / 2))
+      half = Enum.take(value, round(length(value) / 2))
       assert {:ok, half} == Ring.find_nodes(name, key, length(half))
     end)
   end

--- a/test/ets_hash_ring_test.exs
+++ b/test/ets_hash_ring_test.exs
@@ -208,7 +208,7 @@ defmodule ETSHashRingOperationsTest do
       assert {:ok, value} == Ring.find_nodes(name, key, length(value))
 
       # assert that a lookup of the first half of these items returns the correct half.
-      half = Enum.take(value, ceil(length(value) / 2))
+      half = Enum.take(value, Kernel.ceil(length(value) / 2))
       assert {:ok, half} == Ring.find_nodes(name, key, length(half))
     end)
   end

--- a/test/ets_hash_ring_test.exs
+++ b/test/ets_hash_ring_test.exs
@@ -208,7 +208,7 @@ defmodule ETSHashRingOperationsTest do
       assert {:ok, value} == Ring.find_nodes(name, key, length(value))
 
       # assert that a lookup of the first half of these items returns the correct half.
-      half = Enum.take(value, round(length(value) / 2))
+      half = Enum.take(value, trunc(Float.ceil(length(value) / 2)))
       assert {:ok, half} == Ring.find_nodes(name, key, length(half))
     end)
   end


### PR DESCRIPTION
[`Kernel.ceil`](https://hexdocs.pm/elixir/Kernel.html#ceil/1) isn't implemented until 1.8.0, so it's been replaced. A better solution is to modify the CI config so that it builds using 1.8.2 and 1.9.4 at the oldest.